### PR TITLE
Fix "Install Git" step on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ This Figma plugin allows you to:
    eval "$(/opt/homebrew/bin/brew shellenv)"
    ```
 3. Install Git:
-   ```   brew install git
+   ```
+   brew install git
    ```
 4. Install Node.js and npm:
    ```


### PR DESCRIPTION
"Install Git" step code was empty due to a formatting error. This fixes that bug.